### PR TITLE
Fix wrong state updates at removing with multiple items

### DIFF
--- a/lib/implicitly_animated_list.dart
+++ b/lib/implicitly_animated_list.dart
@@ -62,42 +62,34 @@ class ImplicitlyAnimatedList<ItemData> extends StatefulWidget {
 class _ImplicitlyAnimatedListState<ItemData>
     extends State<ImplicitlyAnimatedList<ItemData>> {
   final _listKey = GlobalKey<AnimatedListState>();
-  List<ItemData> _dataFromWidget;
-  List<ItemData> _dataForBuild;
+  List<ItemData> _dataForBuild = List.empty(growable: true);
 
   var sizeTween = Tween<double>(begin: 0, end: 1);
 
   @override
   void initState() {
     super.initState();
-    _dataForBuild = widget.itemData;
+
+    _updateData(widget.itemData, _dataForBuild);
   }
 
   @override
   void didUpdateWidget(Widget oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (_dataFromWidget == null) {
-      _dataFromWidget = widget.itemData;
-      _updateData(List.from(_dataFromWidget), List.from(_dataForBuild));
-      return;
-    }
-
-    bool hasNewItems = widget.itemData.any((e) => !_dataFromWidget.contains(e));
+    bool hasNewItems = widget.itemData.any((e) => !_dataForBuild.contains(e));
     bool hasRemovedItems =
-        _dataFromWidget.any((e) => !widget.itemData.contains(e));
+        _dataForBuild.any((e) => !widget.itemData.contains(e));
     if (hasNewItems || hasRemovedItems) {
-      _dataFromWidget = widget.itemData;
-      _updateData(List.from(_dataFromWidget), List.from(_dataForBuild));
+      _updateData(widget.itemData, _dataForBuild);
     }
   }
 
   Future<void> _updateData(List<ItemData> from, List<ItemData> to) async {
-    final operations = await diff(from, to);
+    final operations = await diff(to, from);
     setState(() {
       for (final op in operations) {
-        op.applyTo(from);
-        _dataForBuild = from;
+        op.applyTo(to);
 
         if (op.isInsertion) {
           _listKey.currentState.insertItem(op.index);


### PR DESCRIPTION
Just encountered this bug, using the package in production. When removing items and still having at least 2 items in the list after, it was popping up another RangeError.

Is somehow part of #1.

At newline 86 the arguments of the function `diff(from, to)` were switched. I think this is the main issue. I also did remove the `_dataFromWidget` state. Hopefully, this will make it easier to maintain.

The state is driving me crazy. We should write some tests in near future 😉