### PR TITLE
Fix list not updating when order changes.

### DIFF
--- a/lib/implicitly_animated_list.dart
+++ b/lib/implicitly_animated_list.dart
@@ -79,10 +79,7 @@ class _ImplicitlyAnimatedListState<ItemData>
   void didUpdateWidget(ImplicitlyAnimatedList<ItemData> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    bool hasNewItems = widget.itemData.any((e) => !_dataForBuild.contains(e));
-    bool hasRemovedItems =
-        _dataForBuild.any((e) => !widget.itemData.contains(e));
-    if (hasNewItems || hasRemovedItems) {
+    if (!listEquals(widget.itemData, _dataForBuild)) {
       _updateData(widget.itemData, _dataForBuild);
     }
   }


### PR DESCRIPTION
The previous didUpdateWidget method did not check the order of the list, it only checked if an item was removed or added. e.g. [3,2] => [3,2,1] would animate, but [3,2,1]  => [1,2,3] would not animate.

listEquals fixes this issue by comparing the two lists for element-by-element equality.